### PR TITLE
Fixes typo in getting syslog_priority from config

### DIFF
--- a/cef.py
+++ b/cef.py
@@ -152,7 +152,7 @@ def _syslog(msg, config):
     logopt = _str2logopt(config.get('syslog_options'))
     facility = _str2facility(config.get('syslog_facility'))
     ident = config.get('syslog_ident', sys.argv[0])
-    priority = _str2priority(config.get('syslog.priority'))
+    priority = _str2priority(config.get('syslog_priority'))
     with _log_lock:
         global _LOG_OPENED
         if _LOG_OPENED != (ident, logopt, facility):


### PR DESCRIPTION
Dots are replaced with underscores by default, so syslog.priority will never be present in config dictionary.